### PR TITLE
Use first tile from walls sprite sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Wolf-3D
 Reading "Masters of Doom". Got inspired to remake Wolfenstein3D
 
-This is stalled as I either switch to 2D rendering, increase performance 
+This is stalled as I either switch to 2D rendering, increase performance
 of the 3D renderer, or find a clever datastructure that would reduce the
 reliance on renderer iteration performance.
+
+## Assets
+
+The PNG files inside `assets/` are sprite sheets. `walls.png` contains
+64x64 tiles arranged in a grid. Currently the first tile of this sheet is
+used as the wall texture by the raycaster.

--- a/src/Raycaster.cpp
+++ b/src/Raycaster.cpp
@@ -3,9 +3,13 @@
 #include <cstring>
 
 void Raycaster::LoadTextures() {
-    sf::Image wall_textures;
-    if (wall_textures.loadFromFile("../assets/walls.png")) {
-        tile_map.push_back(wall_textures);
+    sf::Image spriteSheet;
+    if (spriteSheet.loadFromFile("../assets/walls.png")) {
+        const int SPRITE_SIZE = 64;
+        sf::Image wallTexture;
+        wallTexture.create(SPRITE_SIZE, SPRITE_SIZE);
+        wallTexture.copy(spriteSheet, 0, 0, sf::IntRect(0, 0, SPRITE_SIZE, SPRITE_SIZE), false);
+        tile_map.push_back(wallTexture);
     }
 }
 


### PR DESCRIPTION
## Summary
- slice the wall sprite sheet and load the first tile
- document asset format in README

## Testing
- `g++ -std=c++14 tests/test_camera.cpp src/Camera.cpp src/Map.cpp -Iinclude -o tests/test_camera -lsfml-system && ./tests/test_camera && echo OK`
- `g++ -std=c++14 tests/test_map.cpp src/Map.cpp -Iinclude -o tests/test_map -lsfml-system && ./tests/test_map && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_6873f0550fe8832f84625000f42c8840