### PR TITLE
Add basic enemy animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ used as the wall texture by the raycaster.
 
 `elite-guard.png` is a 4x3 sheet of 64x64 sprites. The middle row contains
 the four-frame walking animation used by the test enemy.
+
+The main loop now spawns a handful of these enemies and advances their
+animation each frame.

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ used as the wall texture by the raycaster.
 `elite-guard.png` is a 4x3 sheet of 64x64 sprites. The middle row contains
 the four-frame walking animation used by the test enemy.
 
-The main loop now spawns a handful of these enemies and advances their
-animation each frame.
+The game spawns a few enemies each frame and projects their world
+coordinates to screen space so they appear in front of the camera.

--- a/README.md
+++ b/README.md
@@ -15,4 +15,6 @@ used as the wall texture by the raycaster.
 the four-frame walking animation used by the test enemy.
 
 The game spawns a few enemies each frame and projects their world
-coordinates to screen space so they appear in front of the camera.
+coordinates to screen space so they appear in front of the camera. The camera
+faces along the +X axis by default so the first enemy is positioned two units
+ahead based on the current yaw.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ reliance on renderer iteration performance.
 The PNG files inside `assets/` are sprite sheets. `walls.png` contains
 64x64 tiles arranged in a grid. Currently the first tile of this sheet is
 used as the wall texture by the raycaster.
+
+`elite-guard.png` is a 4x3 sheet of 64x64 sprites. The middle row contains
+the four-frame walking animation used by the test enemy.

--- a/include/Animator.h
+++ b/include/Animator.h
@@ -1,0 +1,12 @@
+#pragma once
+class Animator {
+public:
+    Animator(int frameCount=1, float frameTime=0.2f);
+    void update(float dt);
+    int getFrame() const { return currentFrame; }
+private:
+    int frames;
+    float frameTime;
+    float elapsed{0.f};
+    int currentFrame{0};
+};

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -18,8 +18,8 @@ public:
 
     void setDirection (sf::Vector2f direction);
     void moveDirection (sf::Vector2f direction);
-    sf::Vector2f getDirectionPolar();
-    sf::Vector3f getDirectionCartesian();
+    sf::Vector2f getDirectionPolar() const;
+    sf::Vector3f getDirectionCartesian() const;
 
 private:
 

--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -8,6 +8,7 @@ public:
     bool load(const std::string &spriteSheetPath);
     void setPosition(const sf::Vector2f &pos);
     sf::Vector2f getPosition() const;
+    void setVelocity(const sf::Vector2f &v) { velocity = v; }
     void update(float dt);
     void draw(sf::RenderWindow &window);
     int getCurrentFrame() const { return animator.getFrame(); }
@@ -18,4 +19,5 @@ private:
     int frameWidth{64};
     int frameHeight{64};
     Animator animator{4, 0.2f};
+    sf::Vector2f velocity{0.f, 0.f};
 };

--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -12,7 +12,7 @@ public:
     sf::Vector2f getPosition() const;
     void setVelocity(const sf::Vector2f &v) { velocity = v; }
     void update(float dt);
-    void draw(sf::RenderWindow &window, const Camera &camera, float fovDeg);
+    void draw(sf::RenderTarget &target, const Camera &camera, float fovDeg);
     int getCurrentFrame() const { return animator.getFrame(); }
 
 private:

--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <SFML/Graphics.hpp>
 #include "Animator.h"
+#include "Camera.h"
+#include "Projection.h"
 
 class Enemy {
 public:
@@ -10,7 +12,7 @@ public:
     sf::Vector2f getPosition() const;
     void setVelocity(const sf::Vector2f &v) { velocity = v; }
     void update(float dt);
-    void draw(sf::RenderWindow &window);
+    void draw(sf::RenderWindow &window, const Camera &camera, float fovDeg);
     int getCurrentFrame() const { return animator.getFrame(); }
 
 private:
@@ -20,4 +22,5 @@ private:
     int frameHeight{64};
     Animator animator{4, 0.2f};
     sf::Vector2f velocity{0.f, 0.f};
+    sf::Vector2f position{0.f, 0.f};
 };

--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include "Animator.h"
+
+class Enemy {
+public:
+    Enemy();
+    bool load(const std::string &spriteSheetPath);
+    void setPosition(const sf::Vector2f &pos);
+    sf::Vector2f getPosition() const;
+    void update(float dt);
+    void draw(sf::RenderWindow &window);
+    int getCurrentFrame() const { return animator.getFrame(); }
+
+private:
+    sf::Texture texture;
+    sf::Sprite sprite;
+    int frameWidth{64};
+    int frameHeight{64};
+    Animator animator{4, 0.2f};
+};

--- a/include/Enemy.h
+++ b/include/Enemy.h
@@ -10,6 +10,8 @@ public:
     bool load(const std::string &spriteSheetPath);
     void setPosition(const sf::Vector2f &pos);
     sf::Vector2f getPosition() const;
+    void setScreenPosition(const sf::Vector2f &pos);
+    void drawSprite(sf::RenderTarget &target);
     void setVelocity(const sf::Vector2f &v) { velocity = v; }
     void update(float dt);
     void draw(sf::RenderTarget &target, const Camera &camera, float fovDeg);

--- a/include/Projection.h
+++ b/include/Projection.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "Camera.h"
+#include <SFML/Graphics.hpp>
+#include <cmath>
+
+inline bool WorldToScreen(const sf::Vector2f& pos,
+                          const Camera& cam,
+                          float fovDeg,
+                          sf::Vector2u screen,
+                          sf::Vector2f& outPos,
+                          float& outScale)
+{
+    sf::Vector3f camPos = cam.getPosition();
+    float yaw = cam.getDirectionPolar().y;
+    float dx = pos.x - camPos.x;
+    float dy = pos.y - camPos.y;
+    float angle = std::atan2(dy, dx) - yaw;
+    while (angle < -PI_F) angle += 2 * PI_F;
+    while (angle > PI_F) angle -= 2 * PI_F;
+    float fovRad = DegreesToRadians(fovDeg);
+    float half = fovRad / 2.f;
+    if (std::abs(angle) > half)
+        return false;
+    float normX = (angle + half) / fovRad;
+    outPos.x = normX * static_cast<float>(screen.x);
+    outPos.y = screen.y / 2.f;
+    float dist = std::sqrt(dx * dx + dy * dy);
+    if (dist < 0.01f) dist = 0.01f;
+    outScale = 1.f / dist;
+    return true;
+}

--- a/src/Animator.cpp
+++ b/src/Animator.cpp
@@ -1,0 +1,12 @@
+#include "Animator.h"
+
+Animator::Animator(int frameCount, float frameTime)
+    : frames(frameCount), frameTime(frameTime) {}
+
+void Animator::update(float dt) {
+    elapsed += dt;
+    if (elapsed >= frameTime && frames > 0) {
+        elapsed -= frameTime;
+        currentFrame = (currentFrame + 1) % frames;
+    }
+}

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -75,10 +75,10 @@ void Camera::moveDirection (sf::Vector2f direction){
     this->direction += direction;
 }
 
-sf::Vector2f Camera::getDirectionPolar(){
+sf::Vector2f Camera::getDirectionPolar() const{
     return direction;
 }
 
-sf::Vector3f Camera::getDirectionCartesian(){
+sf::Vector3f Camera::getDirectionCartesian() const{
     return SphereToCart(direction);
 }

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -1,0 +1,29 @@
+#include "Enemy.h"
+
+Enemy::Enemy() {}
+
+bool Enemy::load(const std::string &spriteSheetPath) {
+    if (!texture.loadFromFile(spriteSheetPath))
+        return false;
+    sprite.setTexture(texture);
+    sprite.setTextureRect(sf::IntRect(0, frameHeight, frameWidth, frameHeight));
+    return true;
+}
+
+void Enemy::setPosition(const sf::Vector2f &pos) {
+    sprite.setPosition(pos);
+}
+
+sf::Vector2f Enemy::getPosition() const {
+    return sprite.getPosition();
+}
+
+void Enemy::update(float dt) {
+    animator.update(dt);
+    sprite.setTextureRect(sf::IntRect(animator.getFrame() * frameWidth,
+                                      frameHeight, frameWidth, frameHeight));
+}
+
+void Enemy::draw(sf::RenderWindow &window) {
+    window.draw(sprite);
+}

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -26,15 +26,16 @@ void Enemy::update(float dt) {
     position += velocity * dt;
 }
 
-void Enemy::draw(sf::RenderWindow &window, const Camera &camera, float fovDeg) {
+void Enemy::draw(sf::RenderTarget &target, const Camera &camera, float fovDeg) {
     sf::Vector2f screenPos;
     float scale;
-    if (!WorldToScreen(position, camera, fovDeg, window.getSize(), screenPos, scale))
+    sf::Vector2u size = target.getSize();
+    if (!WorldToScreen(position, camera, fovDeg, size, screenPos, scale))
         return;
     float baseSize = 150.f; // constant for on-screen scaling
     float pixelSize = baseSize * scale;
     sprite.setPosition(screenPos);
     sprite.setScale(pixelSize / frameWidth, pixelSize / frameHeight);
     sprite.setOrigin(frameWidth / 2.f, frameHeight);
-    window.draw(sprite);
+    target.draw(sprite);
 }

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -1,10 +1,13 @@
 #include "Enemy.h"
+#include <iostream>
 
 Enemy::Enemy() {}
 
 bool Enemy::load(const std::string &spriteSheetPath) {
-    if (!texture.loadFromFile(spriteSheetPath))
+    if (!texture.loadFromFile(spriteSheetPath)) {
+        std::cerr << "Failed to load sprite sheet: " << spriteSheetPath << std::endl;
         return false;
+    }
     sprite.setTexture(texture);
     sprite.setTextureRect(sf::IntRect(0, frameHeight, frameWidth, frameHeight));
     sprite.setOrigin(frameWidth / 2.f, frameHeight);

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -7,25 +7,34 @@ bool Enemy::load(const std::string &spriteSheetPath) {
         return false;
     sprite.setTexture(texture);
     sprite.setTextureRect(sf::IntRect(0, frameHeight, frameWidth, frameHeight));
-    sprite.setOrigin(frameWidth / 2.f, frameHeight / 2.f);
+    sprite.setOrigin(frameWidth / 2.f, frameHeight);
     return true;
 }
 
 void Enemy::setPosition(const sf::Vector2f &pos) {
-    sprite.setPosition(pos);
+    position = pos;
 }
 
 sf::Vector2f Enemy::getPosition() const {
-    return sprite.getPosition();
+    return position;
 }
 
 void Enemy::update(float dt) {
     animator.update(dt);
     sprite.setTextureRect(sf::IntRect(animator.getFrame() * frameWidth,
                                       frameHeight, frameWidth, frameHeight));
-    sprite.move(velocity * dt);
+    position += velocity * dt;
 }
 
-void Enemy::draw(sf::RenderWindow &window) {
+void Enemy::draw(sf::RenderWindow &window, const Camera &camera, float fovDeg) {
+    sf::Vector2f screenPos;
+    float scale;
+    if (!WorldToScreen(position, camera, fovDeg, window.getSize(), screenPos, scale))
+        return;
+    float baseSize = 150.f; // constant for on-screen scaling
+    float pixelSize = baseSize * scale;
+    sprite.setPosition(screenPos);
+    sprite.setScale(pixelSize / frameWidth, pixelSize / frameHeight);
+    sprite.setOrigin(frameWidth / 2.f, frameHeight);
     window.draw(sprite);
 }

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -7,6 +7,7 @@ bool Enemy::load(const std::string &spriteSheetPath) {
         return false;
     sprite.setTexture(texture);
     sprite.setTextureRect(sf::IntRect(0, frameHeight, frameWidth, frameHeight));
+    sprite.setOrigin(frameWidth / 2.f, frameHeight / 2.f);
     return true;
 }
 
@@ -22,6 +23,7 @@ void Enemy::update(float dt) {
     animator.update(dt);
     sprite.setTextureRect(sf::IntRect(animator.getFrame() * frameWidth,
                                       frameHeight, frameWidth, frameHeight));
+    sprite.move(velocity * dt);
 }
 
 void Enemy::draw(sf::RenderWindow &window) {

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -19,6 +19,14 @@ sf::Vector2f Enemy::getPosition() const {
     return position;
 }
 
+void Enemy::setScreenPosition(const sf::Vector2f &pos) {
+    sprite.setPosition(pos);
+}
+
+void Enemy::drawSprite(sf::RenderTarget &target) {
+    target.draw(sprite);
+}
+
 void Enemy::update(float dt) {
     animator.update(dt);
     sprite.setTextureRect(sf::IntRect(animator.getFrame() * frameWidth,

--- a/src/Raycaster.cpp
+++ b/src/Raycaster.cpp
@@ -4,7 +4,11 @@
 
 void Raycaster::LoadTextures() {
     sf::Image spriteSheet;
-    if (spriteSheet.loadFromFile("../assets/walls.png")) {
+    if (!spriteSheet.loadFromFile("assets/walls.png"))
+        spriteSheet.loadFromFile("../assets/walls.png");
+    if (!spriteSheet.getSize().x)
+        return;
+    {
         const int SPRITE_SIZE = 64;
         sf::Image wallTexture;
         wallTexture.create(SPRITE_SIZE, SPRITE_SIZE);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,8 +26,9 @@ float elap_time() {
 
 int main() {
 	
-	std::mt19937 rng(time(NULL));
-	std::uniform_int_distribution<int> rgen(100, 400);
+    std::mt19937 rng(time(NULL));
+    std::uniform_int_distribution<int> xdist(0, 800 - 64);
+    std::uniform_int_distribution<int> ydist(0, 800 - 64);
 
         sf::RenderWindow window(sf::VideoMode(800, 800), "Wolf-3D");
         window.setMouseCursorVisible(false);
@@ -55,7 +56,8 @@ int main() {
     for (int i = 0; i < 5; ++i) {
         Enemy e;
         e.load("assets/elite-guard.png");
-        e.setPosition(sf::Vector2f(rgen(rng), rgen(rng)));
+        e.setPosition(sf::Vector2f(xdist(rng), ydist(rng)));
+        e.setVelocity(sf::Vector2f(20.f, 0.f));
         enemies.push_back(e);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,7 +166,7 @@ int main() {
 
                 for (auto &enemy : enemies) {
                     enemy.update(static_cast<float>(delta_time));
-                    enemy.draw(window);
+                    enemy.draw(window, *camera, 60.f);
                 }
 
                 fps.draw(&window);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <SFML/Graphics.hpp>
 #include <random>
 #include <chrono>
+#include <cmath>
 #include <Camera.h>
 #include <Map.h>
 #include <Raycaster.h>
@@ -37,7 +38,8 @@ int main() {
 
     std::shared_ptr<Camera> camera(new Camera);
     camera->setPosition(sf::Vector3f(3.1f, 3.1f, 3.1f));
-    camera->setDirection(sf::Vector2f(1.0f, 0.0f));
+    // face down the +X axis
+    camera->setDirection(sf::Vector2f(0.0f, 0.0f));
 
     Map *map = new Map;
 
@@ -61,8 +63,10 @@ int main() {
         Enemy e;
         e.load("assets/elite-guard.png");
         sf::Vector3f camPos = camera->getPosition();
-        sf::Vector3f dir = camera->getDirectionCartesian();
-        sf::Vector2f wpos(camPos.x + dir.x * 2.f, camPos.y + dir.y * 2.f);
+        float yaw = camera->getDirectionPolar().y;
+        sf::Vector2f forward(std::cos(yaw), std::sin(yaw));
+        sf::Vector2f wpos(camPos.x + forward.x * 2.f,
+                         camPos.y + forward.y * 2.f);
         e.setPosition(wpos);
         enemies.push_back(e);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,9 @@
 #include <Camera.h>
 #include <Map.h>
 #include <Raycaster.h>
+#include "Enemy.h"
 #include "util.hpp"
+#include <vector>
 
 float elap_time() {
 	static std::chrono::time_point<std::chrono::system_clock> start;
@@ -48,6 +50,14 @@ int main() {
 
     raycaster.CreateViewport(sf::Vector2i(800, 800), sf::Vector2f(80.0f, 80.0f));
     raycaster.LoadTextures();
+
+    std::vector<Enemy> enemies;
+    for (int i = 0; i < 5; ++i) {
+        Enemy e;
+        e.load("assets/elite-guard.png");
+        e.setPosition(sf::Vector2f(rgen(rng), rgen(rng)));
+        enemies.push_back(e);
+    }
 
 
 	float physic_step = 0.166f;
@@ -130,10 +140,15 @@ int main() {
 
 		window.clear(sf::Color::White);
 
-		raycaster.Draw(&window);
+                raycaster.Draw(&window);
 
-		fps.draw(&window);
-		fps.frame(delta_time);
+                for (auto &enemy : enemies) {
+                    enemy.update(static_cast<float>(delta_time));
+                    enemy.draw(window);
+                }
+
+                fps.draw(&window);
+                fps.frame(delta_time);
 
 		window.display();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,10 +25,8 @@ float elap_time() {
 }
 
 int main() {
-	
+
     std::mt19937 rng(time(NULL));
-    std::uniform_int_distribution<int> xdist(0, 800 - 64);
-    std::uniform_int_distribution<int> ydist(0, 800 - 64);
 
         sf::RenderWindow window(sf::VideoMode(800, 800), "Wolf-3D");
         window.setMouseCursorVisible(false);
@@ -52,11 +50,33 @@ int main() {
     raycaster.CreateViewport(sf::Vector2i(800, 800), sf::Vector2f(80.0f, 80.0f));
     raycaster.LoadTextures();
 
+    sf::Vector3i dims = map->getDimensions();
+    std::uniform_real_distribution<float> xdist(0.f, static_cast<float>(dims.x));
+    std::uniform_real_distribution<float> ydist(0.f, static_cast<float>(dims.y));
+    float scale = 800.f / static_cast<float>(std::max(dims.x, dims.y));
+
+    auto toScreen = [&](sf::Vector2f world){
+        return sf::Vector2f(world.x * scale, world.y * scale);
+    };
+
     std::vector<Enemy> enemies;
-    for (int i = 0; i < 5; ++i) {
+
+    // Spawn one enemy directly in front of the player
+    {
         Enemy e;
         e.load("assets/elite-guard.png");
-        e.setPosition(sf::Vector2f(xdist(rng), ydist(rng)));
+        sf::Vector3f camPos = camera->getPosition();
+        sf::Vector3f dir = camera->getDirectionCartesian();
+        sf::Vector2f wpos(camPos.x + dir.x * 2.f, camPos.y + dir.y * 2.f);
+        e.setPosition(toScreen(wpos));
+        enemies.push_back(e);
+    }
+
+    for (int i = 0; i < 4; ++i) {
+        Enemy e;
+        e.load("assets/elite-guard.png");
+        sf::Vector2f wpos(xdist(rng), ydist(rng));
+        e.setPosition(toScreen(wpos));
         e.setVelocity(sf::Vector2f(20.f, 0.f));
         enemies.push_back(e);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,11 +53,6 @@ int main() {
     sf::Vector3i dims = map->getDimensions();
     std::uniform_real_distribution<float> xdist(0.f, static_cast<float>(dims.x));
     std::uniform_real_distribution<float> ydist(0.f, static_cast<float>(dims.y));
-    float scale = 800.f / static_cast<float>(std::max(dims.x, dims.y));
-
-    auto toScreen = [&](sf::Vector2f world){
-        return sf::Vector2f(world.x * scale, world.y * scale);
-    };
 
     std::vector<Enemy> enemies;
 
@@ -68,7 +63,7 @@ int main() {
         sf::Vector3f camPos = camera->getPosition();
         sf::Vector3f dir = camera->getDirectionCartesian();
         sf::Vector2f wpos(camPos.x + dir.x * 2.f, camPos.y + dir.y * 2.f);
-        e.setPosition(toScreen(wpos));
+        e.setPosition(wpos);
         enemies.push_back(e);
     }
 
@@ -76,7 +71,7 @@ int main() {
         Enemy e;
         e.load("assets/elite-guard.png");
         sf::Vector2f wpos(xdist(rng), ydist(rng));
-        e.setPosition(toScreen(wpos));
+        e.setPosition(wpos);
         e.setVelocity(sf::Vector2f(20.f, 0.f));
         enemies.push_back(e);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,11 @@ int main() {
     // Spawn one enemy directly in front of the player
     {
         Enemy e;
-        e.load("assets/elite-guard.png");
+        if(!e.load("assets/elite-guard.png"))
+        {
+            std::cerr << "Enemy sprite failed to load" << std::endl;
+            return 1;
+        }
         sf::Vector3f camPos = camera->getPosition();
         float yaw = camera->getDirectionPolar().y;
         sf::Vector2f forward(std::cos(yaw), std::sin(yaw));
@@ -73,7 +77,11 @@ int main() {
 
     for (int i = 0; i < 4; ++i) {
         Enemy e;
-        e.load("assets/elite-guard.png");
+        if(!e.load("assets/elite-guard.png"))
+        {
+            std::cerr << "Enemy sprite failed to load" << std::endl;
+            return 1;
+        }
         sf::Vector2f wpos(xdist(rng), ydist(rng));
         e.setPosition(wpos);
         e.setVelocity(sf::Vector2f(20.f, 0.f));

--- a/tests/test_animator.cpp
+++ b/tests/test_animator.cpp
@@ -1,0 +1,12 @@
+#include "Animator.h"
+#include <cassert>
+
+int main() {
+    Animator a(4, 0.1f);
+    int f = a.getFrame();
+    a.update(0.11f);
+    assert(a.getFrame() == (f+1)%4);
+    for(int i=0;i<10;i++) a.update(0.11f);
+    assert(a.getFrame() >=0 && a.getFrame()<4);
+    return 0;
+}

--- a/tests/test_enemy_load.cpp
+++ b/tests/test_enemy_load.cpp
@@ -1,0 +1,8 @@
+#include "Enemy.h"
+#include <cassert>
+
+int main(){
+    Enemy e;
+    assert(!e.load("no_such_file.png"));
+    return 0;
+}

--- a/tests/test_render.cpp
+++ b/tests/test_render.cpp
@@ -1,0 +1,30 @@
+#include "Enemy.h"
+#include "Camera.h"
+#include <SFML/Graphics.hpp>
+#include <cassert>
+
+int main() {
+    Enemy e;
+    assert(e.load("assets/elite-guard.png"));
+    e.setPosition(sf::Vector2f(2.f, 0.f));
+    Camera cam;
+    cam.setPosition(sf::Vector3f(0.f, 0.f, 0.f));
+    cam.setDirection(sf::Vector2f(0.f, 0.f));
+
+    sf::RenderTexture tex;
+    bool ok = tex.create(200, 200);
+    assert(ok);
+    tex.clear(sf::Color::Black);
+
+    e.draw(tex, cam, 60.f);
+    tex.display();
+
+    sf::Image img = tex.getTexture().copyToImage();
+    sf::Vector2u size = img.getSize();
+    unsigned long sum = 0;
+    for(unsigned y=0; y<size.y; ++y)
+        for(unsigned x=0; x<size.x; ++x)
+            sum += img.getPixel(x,y).a;
+    assert(sum > 0);
+    return 0;
+}

--- a/tests/test_render.cpp
+++ b/tests/test_render.cpp
@@ -1,5 +1,7 @@
 #include "Enemy.h"
 #include "Camera.h"
+#include "Map.h"
+#include "Raycaster.h"
 #include <SFML/Graphics.hpp>
 #include <cassert>
 
@@ -7,19 +9,28 @@ int main() {
     Enemy e;
     assert(e.load("assets/elite-guard.png"));
     e.setPosition(sf::Vector2f(2.f, 0.f));
-    Camera cam;
-    cam.setPosition(sf::Vector3f(0.f, 0.f, 0.f));
-    cam.setDirection(sf::Vector2f(0.f, 0.f));
+    std::shared_ptr<Camera> cam(new Camera);
+    cam->setPosition(sf::Vector3f(0.f, 0.f, 0.f));
+    cam->setDirection(sf::Vector2f(0.f, 0.f));
 
-    sf::RenderTexture tex;
-    bool ok = tex.create(200, 200);
-    assert(ok);
-    tex.clear(sf::Color::Black);
+    Map map;
+    map.Init(sf::Vector3i(10,10,1));
 
-    e.draw(tex, cam, 60.f);
-    tex.display();
+    Raycaster ray(&map, cam);
+    ray.CreateViewport(sf::Vector2i(200,200), sf::Vector2f(60.f,60.f));
+    ray.LoadTextures();
+    ray.Cast();
 
-    sf::Image img = tex.getTexture().copyToImage();
+    sf::RenderWindow window(sf::VideoMode(200,200), "test", sf::Style::Default);
+    window.clear(sf::Color::Black);
+    ray.Draw(&window);
+    e.draw(window, *cam, 60.f);
+    window.display();
+
+    sf::Texture capture;
+    capture.create(200,200);
+    capture.update(window);
+    sf::Image img = capture.copyToImage();
     sf::Vector2u size = img.getSize();
     unsigned long sum = 0;
     for(unsigned y=0; y<size.y; ++y)

--- a/tests/test_sprite.cpp
+++ b/tests/test_sprite.cpp
@@ -1,0 +1,21 @@
+#include "Enemy.h"
+#include <SFML/Graphics.hpp>
+#include <cassert>
+
+int main(){
+    Enemy e;
+    assert(e.load("assets/elite-guard.png"));
+    sf::RenderTexture tex;
+    tex.create(128,128);
+    e.setScreenPosition(sf::Vector2f(64.f,64.f));
+    tex.clear(sf::Color::Black);
+    e.drawSprite(tex);
+    tex.display();
+    sf::Image img = tex.getTexture().copyToImage();
+    unsigned long sum = 0;
+    for(unsigned y=0;y<img.getSize().y;++y)
+        for(unsigned x=0;x<img.getSize().x;++x)
+            sum += img.getPixel(x,y).a;
+    assert(sum>0);
+    return 0;
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1,0 +1,12 @@
+#include "util.hpp"
+#include <cassert>
+
+int main() {
+    sf::Vector2f pos(5.f, 10.f);
+    sf::Vector3i dims(30, 50, 1);
+    float scale = 800.f / static_cast<float>(std::max(dims.x, dims.y));
+    sf::Vector2f screen(pos.x * scale, pos.y * scale);
+    assert(screen.x >= 0.f && screen.x <= 800.f);
+    assert(screen.y >= 0.f && screen.y <= 800.f);
+    return 0;
+}

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1,12 +1,18 @@
-#include "util.hpp"
+#include "Projection.h"
 #include <cassert>
+#include <cmath>
 
 int main() {
-    sf::Vector2f pos(5.f, 10.f);
-    sf::Vector3i dims(30, 50, 1);
-    float scale = 800.f / static_cast<float>(std::max(dims.x, dims.y));
-    sf::Vector2f screen(pos.x * scale, pos.y * scale);
-    assert(screen.x >= 0.f && screen.x <= 800.f);
-    assert(screen.y >= 0.f && screen.y <= 800.f);
+    Camera cam;
+    cam.setPosition(sf::Vector3f(0.f, 0.f, 0.f));
+    cam.setDirection(sf::Vector2f(0.f, 0.f));
+
+    sf::Vector2f screen;
+    float scale;
+    bool vis = WorldToScreen(sf::Vector2f(1.f, 0.f), cam, 60.f,
+                             sf::Vector2u(800, 800), screen, scale);
+    assert(vis);
+    assert(std::abs(screen.x - 400.f) < 1.f);
+    assert(scale > 0.f);
     return 0;
 }


### PR DESCRIPTION
## Summary
- add simple animator class to handle animation frames
- add enemy class that uses the animator
- document new elite guard sprite sheet in README
- test animator frame update logic

## Testing
- `g++ -std=c++14 tests/test_camera.cpp src/Camera.cpp src/Map.cpp -Iinclude -o tests/test_camera && ./tests/test_camera`
- `g++ -std=c++14 tests/test_map.cpp src/Map.cpp -Iinclude -o tests/test_map && ./tests/test_map`
- `g++ -std=c++14 tests/test_mouse.cpp src/Camera.cpp src/Map.cpp -Iinclude -o tests/test_mouse && ./tests/test_mouse`
- `g++ -std=c++14 tests/test_raycast.cpp src/Map.cpp -Iinclude -o tests/test_raycast && ./tests/test_raycast`
- `g++ -std=c++14 tests/test_animator.cpp src/Animator.cpp -Iinclude -o tests/test_animator && ./tests/test_animator`


------
https://chatgpt.com/codex/tasks/task_e_6873f3fc7c54832fa052eb8982e3185e